### PR TITLE
chore: add CI pipeline and clean up deprecated APIs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,31 @@
+name: Tests
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: ["1.21", "1.22", "1.23"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go ${{ matrix.go-version }}
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go-version }}
+
+      - name: Build
+        run: go build ./...
+
+      - name: Test
+        run: go test -race -v ./...
+
+      - name: Vet
+        run: go vet ./...

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 httpreaderat
 ============
 
-[![GoDoc](https://godoc.org/github.com/snabb/httpreaderat?status.svg)](https://godoc.org/github.com/snabb/httpreaderat)
+[![Tests](https://github.com/snabb/httpreaderat/actions/workflows/test.yml/badge.svg)](https://github.com/snabb/httpreaderat/actions/workflows/test.yml)
+[![Go Reference](https://pkg.go.dev/badge/github.com/snabb/httpreaderat.svg)](https://pkg.go.dev/github.com/snabb/httpreaderat)
 
 Go package httpreaderat implements io.ReaderAt that makes HTTP Range Requests.
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/snabb/httpreaderat
 
-go 1.18
+go 1.21
 
 require github.com/stretchr/testify v1.10.0
 

--- a/httpreaderat.go
+++ b/httpreaderat.go
@@ -201,21 +201,11 @@ func (ra *HTTPReaderAt) readAt(p []byte, off int64, initialize bool) (int, error
 	return n, err
 }
 
-func cloneHeader(h http.Header) http.Header {
-	h2 := make(http.Header, len(h))
-	for k, vv := range h {
-		vv2 := make([]string, len(vv))
-		copy(vv2, vv)
-		h2[k] = vv2
-	}
-	return h2
-}
-
 func (ra *HTTPReaderAt) copyReq() *http.Request {
 	out := *ra.req
 	out.Body = nil
 	out.ContentLength = 0
-	out.Header = cloneHeader(ra.req.Header)
+	out.Header = ra.req.Header.Clone()
 
 	return &out
 }

--- a/httpreaderat_test.go
+++ b/httpreaderat_test.go
@@ -69,7 +69,7 @@ func (ra *readerAtFixture) TestRangeSupportInitial() {
 	ra.NotNil(reader)
 }
 
-func (ra *readerAtFixture) TestRangeSupportIntialEmptyResponse() {
+func (ra *readerAtFixture) TestRangeSupportInitialEmptyResponse() {
 	ra.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		rnge := r.Header.Get("Range")
 		ra.Equal(rnge, "bytes=0-0")
@@ -83,7 +83,7 @@ func (ra *readerAtFixture) TestRangeSupportIntialEmptyResponse() {
 	ra.Nil(reader)
 }
 
-func (ra *readerAtFixture) TestRangeSupportIntialTooMuchResponse() {
+func (ra *readerAtFixture) TestRangeSupportInitialTooMuchResponse() {
 	ra.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		rnge := r.Header.Get("Range")
 		ra.Equal(rnge, "bytes=0-0")
@@ -118,7 +118,7 @@ func (ra *readerAtFixture) TestFile() {
 	ra.Equal(http.DetectContentType(content), "text/plain; charset=utf-8")
 }
 
-func (ra *readerAtFixture) TestParralelFiles() {
+func (ra *readerAtFixture) TestParallelFiles() {
 	ra.server = httptest.NewServer(http.FileServer(http.Dir("./fixtures")))
 
 	reader, err := ra.reader()

--- a/store.go
+++ b/store.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"io"
-	"io/ioutil"
 	"os"
 )
 
@@ -48,7 +47,7 @@ func (s *StoreFile) ReadFrom(r io.Reader) (n int64, err error) {
 	if s.tmpfile != nil {
 		s.Close()
 	}
-	s.tmpfile, err = ioutil.TempFile("", "gotmp")
+	s.tmpfile, err = os.CreateTemp("", "gotmp")
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
## Summary

- Add GitHub Actions workflow running `go build`, `go test -race`, and `go vet` against Go 1.21/1.22/1.23 on push and PR
- Replace dead `godoc.org` badge with `pkg.go.dev` and add CI status badge to README
- Replace deprecated `ioutil.TempFile` → `os.CreateTemp` and manual `cloneHeader` → `http.Header.Clone()`
- Bump `go.mod` minimum version from 1.18 to 1.21
- Fix test name typos: `Intial` → `Initial` (×2), `Parrallel` → `Parallel`

## Test plan

- [ ] CI pipeline passes on all three Go versions
- [ ] CI badge renders correctly on README after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)