### PR TITLE
Add Codecov coverage reporting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,3 +29,23 @@ jobs:
 
       - name: Vet
         run: go vet ./...
+
+  coverage:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.23"
+
+      - name: Run coverage
+        run: go test -covermode=atomic -coverprofile=coverage.txt ./...
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage.txt

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ httpreaderat
 ============
 
 [![Tests](https://github.com/snabb/httpreaderat/actions/workflows/test.yml/badge.svg)](https://github.com/snabb/httpreaderat/actions/workflows/test.yml)
+[![Codecov](https://codecov.io/gh/snabb/httpreaderat/graph/badge.svg)](https://codecov.io/gh/snabb/httpreaderat)
 [![Go Reference](https://pkg.go.dev/badge/github.com/snabb/httpreaderat.svg)](https://pkg.go.dev/github.com/snabb/httpreaderat)
 
 Go package httpreaderat implements io.ReaderAt that makes HTTP Range Requests.


### PR DESCRIPTION
## Summary
- add a dedicated GitHub Actions coverage job that uploads reports to Codecov
- use the repository CODECOV_TOKEN secret for the upload step
- add a Codecov badge to the README

## Testing
- go test ./...